### PR TITLE
一般ユーザー詳細画面、一般ユーザー名称編集機能実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,10 @@ class ApplicationController < ActionController::Base
 
   # gem deviseを導入するために下記を記載
   def configure_permitted_parameters
-    # /users/sign_up
+    # ユーザー登録時にname,email,password,password_confirmationのストロングパラメータを追加。通常パスワードは不要なはずだが、エラーが出たので追加。
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password, :password_confirmation])
+    # ユーザー編集時にnameのストロングパラメータを追加
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name,:password])
+
   end
 end

--- a/app/controllers/general_users/registrations_controller.rb
+++ b/app/controllers/general_users/registrations_controller.rb
@@ -6,7 +6,7 @@ class GeneralUsers::RegistrationsController < Devise::RegistrationsController
 
   # GET /resource/sign_up
   def new
-     @generaluser = GeneralUser.new
+      @generaluser = GeneralUser.new
      super
   end
 
@@ -17,12 +17,22 @@ class GeneralUsers::RegistrationsController < Devise::RegistrationsController
 
   # GET /resource/edit
   def edit
+    @generaluser = current_general_user
     super
   end
 
   # PUT /resource
   def update
-    super
+     @generaluser = current_general_user
+  if @generaluser.update_without_password(account_update_params)
+    redirect_to after_update_path_for(@generaluser), notice: 'プロフィールが更新されました。'
+    return # ここでアクションを終了させる
+  else
+    render :edit
+    return # render後にアクションを終了させる
+  end
+    super 
+    # この行は実際には到達しないが、独自の更新処理が不要な場合にDeviseのデフォルトの処理を利用するために残しておく
   end
 
   # DELETE /resource
@@ -48,7 +58,7 @@ class GeneralUsers::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 
   # The path used after sign up.
@@ -59,5 +69,19 @@ class GeneralUsers::RegistrationsController < Devise::RegistrationsController
   # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(resource)
     super(resource)
+  end
+
+  # 下記でパスワードなしでデータをアップデートできるようにする。デフォルトだとできない
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+  # プロフィール編集後にトップページでなく、プロフィール画面に飛ぶようにする。
+  def after_update_path_for(resource)
+    # 自分で設定した「マイページ」へのパス
+    general_users_profile_path
+  end
+  # アップデートを実施するときのストロングパラーメータ用メソッド
+  def account_update_params
+    params.require(:general_user).permit(:name)
   end
 end

--- a/app/controllers/general_users_controller.rb
+++ b/app/controllers/general_users_controller.rb
@@ -1,0 +1,5 @@
+class GeneralUsersController < ApplicationController
+  def show
+    @general_users = current_general_user
+  end
+end

--- a/app/helpers/general_users_helper.rb
+++ b/app/helpers/general_users_helper.rb
@@ -1,0 +1,2 @@
+module GeneralUsersHelper
+end

--- a/app/views/general_users/registrations/edit.html.erb
+++ b/app/views/general_users/registrations/edit.html.erb
@@ -1,34 +1,25 @@
+<div class="container home-sections d-flex flex-row justify-content-center
+  align-items-center"
+>
+  <div class="login-section pt-3">
+    <div class="card text-center pt-5 mx-auto" style="width: 23rem;">
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "general_users/shared/error_messages", resource: resource %>
+<%# <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+<div class="card-body">
+<%= form_with model: @generaluser, url: registration_path(resource_name), method: :patch, local: true  do |f|%>
+  <%= devise_error_messages! %>
 
-  <div class="field">
+  <!-- 名前の入力フォームを追加 -->
+  <div class="mb-3 mt-4">
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autofocus: true, placeholder: current_general_user.name %>
+  </div>
+
+  <div class="mb-3 mt-4">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
+    <!-- emailを編集できないようにしたい場合は「disabled: true」オプションを追記する -->
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", disabled: true, placeholder: current_general_user.email %>
   </div>
 
   <div class="actions">
@@ -36,8 +27,10 @@
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
 <%= link_to "Back", :back %>
+</div>
+</div>
+  </div>
+</div>
+<br>
+

--- a/app/views/general_users/show.html.erb
+++ b/app/views/general_users/show.html.erb
@@ -1,0 +1,7 @@
+<h1>プロフィール</h1>
+<h3>ユーザー名</h3>
+<%= @general_users.name %>
+<h3>メールアドレス</h3>
+<%= @general_users.email %>
+<p>編集画面へ</p>
+<%= link_to 'edit', edit_general_user_registration_path %>

--- a/app/views/shared/_header.erb
+++ b/app/views/shared/_header.erb
@@ -16,6 +16,9 @@
       <% end %>%>
       <% if general_user_signed_in? %>
         <li style="margin-left: 20px;">
+          <%= link_to current_general_user.name, general_users_profile_path, style: "color: white; text-decoration: none;" %>
+        </li>
+        <li style="margin-left: 20px;">
           <%= button_to "ログアウト", destroy_general_user_session_path, method: :delete, form: { data: { turbo: false, confirm: "本当にログアウトしますか？" } }, class: "btn btn-link" , style: "color: white; text-decoration: none;"%>
         </li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'general_users/show'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
@@ -18,5 +19,6 @@ Rails.application.routes.draw do
     passwords: "general_users/passwords",
     confirmations: "general_users/confirmations"
   }
+  get "general_users/profile" => "general_users#show"
 
 end


### PR DESCRIPTION
DEVICEを使用したメールと名前、パスワード登録機能の実装。
名前の編集のみ可能とした。
メールアドレスの編集はできないようにした。
ユーザー写真の登録、パスワードの変更はまだ未実装。